### PR TITLE
Refine EF Core mappings for AppDbContext

### DIFF
--- a/src/DomainDrivenDesignShop.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/DomainDrivenDesignShop.Infrastructure/Persistence/AppDbContext.cs
@@ -2,53 +2,15 @@ using DomainDrivenDesignShop.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 
 namespace DomainDrivenDesignShop.Infrastructure.Persistence;
+
 public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
 {
     public DbSet<Product> Products => Set<Product>();
     public DbSet<Order> Orders => Set<Order>();
-    public DbSet<OrderLine> OrderLines => Set<OrderLine>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        // Product
-        modelBuilder.Entity<Product>(b =>
-        {
-            b.HasKey(p => p.Id);
-            b.Property(p => p.Name).IsRequired().HasMaxLength(200);
-
-            b.OwnsOne(p => p.Price, money =>
-            {
-                money.Property(m => m.Amount).HasColumnType("decimal(18,2)");
-                money.Property(m => m.Currency).HasMaxLength(3);
-            });
-        });
-
-
-        // Order
-        modelBuilder.Entity<Order>(b =>
-        {
-            b.HasKey(o => o.Id);
-            b.Property(o => o.CreatedAtUtc).IsRequired();
-            b.Property(o => o.Currency).IsRequired().HasMaxLength(3);
-        });
-
-        // OrderLine
-        modelBuilder.Entity<OrderLine>(b =>
-        {
-            b.HasKey(ol => ol.Id);
-            b.Property(ol => ol.Quantity).IsRequired();
-
-            b.HasOne<Order>()
-                .WithMany(o => o.Lines)
-                .HasForeignKey(ol => ol.OrderId)
-                .OnDelete(DeleteBehavior.Cascade);
-
-            b.OwnsOne(ol => ol.UnitPrice, money =>
-            {
-                money.Property(m => m.Amount).HasColumnType("decimal(18,2)");
-                money.Property(m => m.Currency).HasMaxLength(3);
-            });
-        });
-
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+        base.OnModelCreating(modelBuilder);
     }
 }

--- a/src/DomainDrivenDesignShop.Infrastructure/Persistence/Configurations/OrderConfiguration.cs
+++ b/src/DomainDrivenDesignShop.Infrastructure/Persistence/Configurations/OrderConfiguration.cs
@@ -1,0 +1,57 @@
+using DomainDrivenDesignShop.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DomainDrivenDesignShop.Infrastructure.Persistence.Configurations;
+
+public sealed class OrderConfiguration : IEntityTypeConfiguration<Order>
+{
+    public void Configure(EntityTypeBuilder<Order> builder)
+    {
+        builder.ToTable("Orders");
+
+        builder.HasKey(o => o.Id);
+        builder.Property(o => o.Id).ValueGeneratedNever();
+
+        builder.Property(o => o.CreatedAtUtc)
+               .IsRequired();
+
+        builder.Property(o => o.Currency)
+               .IsRequired()
+               .HasMaxLength(3);
+
+        builder.OwnsMany(o => o.Lines, lineBuilder =>
+        {
+            lineBuilder.ToTable("OrderLines");
+
+            lineBuilder.WithOwner()
+                       .HasForeignKey(l => l.OrderId);
+
+            lineBuilder.HasKey(l => l.Id);
+            lineBuilder.Property(l => l.Id).ValueGeneratedNever();
+
+            lineBuilder.Property(l => l.ProductId)
+                       .IsRequired();
+
+            lineBuilder.Property(l => l.Quantity)
+                       .IsRequired();
+
+            lineBuilder.OwnsOne(l => l.UnitPrice, moneyBuilder =>
+            {
+                moneyBuilder.WithOwner();
+
+                moneyBuilder.Property(m => m.Amount)
+                            .HasPrecision(18, 2)
+                            .IsRequired();
+
+                moneyBuilder.Property(m => m.Currency)
+                            .HasMaxLength(3)
+                            .IsRequired();
+            });
+        });
+
+        builder.Navigation(o => o.Lines)
+               .HasField("_lines")
+               .UsePropertyAccessMode(PropertyAccessMode.Field);
+    }
+}

--- a/src/DomainDrivenDesignShop.Infrastructure/Persistence/Configurations/ProductConfiguration.cs
+++ b/src/DomainDrivenDesignShop.Infrastructure/Persistence/Configurations/ProductConfiguration.cs
@@ -1,0 +1,33 @@
+using DomainDrivenDesignShop.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DomainDrivenDesignShop.Infrastructure.Persistence.Configurations;
+
+public sealed class ProductConfiguration : IEntityTypeConfiguration<Product>
+{
+    public void Configure(EntityTypeBuilder<Product> builder)
+    {
+        builder.ToTable("Products");
+
+        builder.HasKey(p => p.Id);
+        builder.Property(p => p.Id).ValueGeneratedNever();
+
+        builder.Property(p => p.Name)
+               .IsRequired()
+               .HasMaxLength(200);
+
+        builder.OwnsOne(p => p.Price, priceBuilder =>
+        {
+            priceBuilder.WithOwner();
+
+            priceBuilder.Property(m => m.Amount)
+                         .HasPrecision(18, 2)
+                         .IsRequired();
+
+            priceBuilder.Property(m => m.Currency)
+                         .HasMaxLength(3)
+                         .IsRequired();
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- move EF Core configuration for products and orders into dedicated configuration classes
- map order lines as an owned collection using the aggregate backing field to respect DDD boundaries
- update AppDbContext to apply configurations from the assembly

## Testing
- not run (dotnet CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dab57a9d38832fbd361bcef2b9e262