### PR TITLE
Refactor API endpoints into controllers with SQLite persistence

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -33,12 +33,12 @@ dotnet add $SRC_DIR/$SOLUTION_NAME.Api/$SOLUTION_NAME.Api.csproj reference $SRC_
 echo "📥 Instalando paquetes NuGet..."
 # EF Core Infra
 dotnet add $SRC_DIR/$SOLUTION_NAME.Infrastructure/$SOLUTION_NAME.Infrastructure.csproj package Microsoft.EntityFrameworkCore
-dotnet add $SRC_DIR/$SOLUTION_NAME.Infrastructure/$SOLUTION_NAME.Infrastructure.csproj package Microsoft.EntityFrameworkCore.InMemory
+dotnet add $SRC_DIR/$SOLUTION_NAME.Infrastructure/$SOLUTION_NAME.Infrastructure.csproj package Microsoft.EntityFrameworkCore.Sqlite
 dotnet add $SRC_DIR/$SOLUTION_NAME.Infrastructure/$SOLUTION_NAME.Infrastructure.csproj package Microsoft.EntityFrameworkCore.Design
 
 # EF Core Api
 dotnet add $SRC_DIR/$SOLUTION_NAME.Api/$SOLUTION_NAME.Api.csproj package Microsoft.EntityFrameworkCore
-dotnet add $SRC_DIR/$SOLUTION_NAME.Api/$SOLUTION_NAME.Api.csproj package Microsoft.EntityFrameworkCore.InMemory
+dotnet add $SRC_DIR/$SOLUTION_NAME.Api/$SOLUTION_NAME.Api.csproj package Microsoft.EntityFrameworkCore.Sqlite
 
 echo "✅ Todo listo."
 echo "👉 Ahora puedes ejecutar:"

--- a/src/DomainDrivenDesignShop.Api/Controllers/OrdersController.cs
+++ b/src/DomainDrivenDesignShop.Api/Controllers/OrdersController.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+using DomainDrivenDesignShop.Application;
+using DomainDrivenDesignShop.Domain.Abstractions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DomainDrivenDesignShop.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public sealed class OrdersController(
+    CreateOrderHandler createHandler,
+    AddProductToOrderHandler addProductHandler,
+    GetOrderHandler getHandler,
+    ListOrdersHandler listHandler,
+    UpdateOrderHandler updateHandler,
+    DeleteOrderHandler deleteHandler) : ControllerBase
+{
+    private readonly CreateOrderHandler _createHandler = createHandler;
+    private readonly AddProductToOrderHandler _addProductHandler = addProductHandler;
+    private readonly GetOrderHandler _getHandler = getHandler;
+    private readonly ListOrdersHandler _listHandler = listHandler;
+    private readonly UpdateOrderHandler _updateHandler = updateHandler;
+    private readonly DeleteOrderHandler _deleteHandler = deleteHandler;
+
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<OrderDto>>> GetAllAsync(CancellationToken ct)
+    {
+        var result = await _listHandler.HandleAsync(new ListOrdersQuery(), ct);
+        return Ok(result);
+    }
+
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<OrderDto>> GetByIdAsync(Guid id, CancellationToken ct)
+    {
+        try
+        {
+            var result = await _getHandler.HandleAsync(new GetOrderQuery(id), ct);
+            return Ok(result);
+        }
+        catch (DomainNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+    }
+
+
+    [HttpPost]
+    public async Task<ActionResult<CreateOrderResult>> CreateAsync([FromBody] CreateOrderRequest request, CancellationToken ct)
+    {
+        try
+        {
+            var result = await _createHandler.HandleAsync(new CreateOrderCommand(request.Currency), ct);
+            return CreatedAtAction(nameof(GetByIdAsync), new { id = result.OrderId }, result);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+
+
+    [HttpPost("{orderId:guid}/lines")]
+    public async Task<IActionResult> AddLineAsync(Guid orderId, [FromBody] AddLineRequest request, CancellationToken ct)
+    {
+        try
+        {
+            await _addProductHandler.HandleAsync(new AddProductToOrderCommand(orderId, request.ProductId, request.Quantity), ct);
+            return NoContent();
+        }
+        catch (DomainNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+        catch (DomainRuleViolationException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> UpdateAsync(Guid id, [FromBody] UpdateOrderRequest request, CancellationToken ct)
+    {
+        try
+        {
+            await _updateHandler.HandleAsync(new UpdateOrderCommand(id, request.Currency), ct);
+            return NoContent();
+        }
+        catch (DomainNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+        catch (DomainRuleViolationException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteAsync(Guid id, CancellationToken ct)
+    {
+        try
+        {
+            await _deleteHandler.HandleAsync(new DeleteOrderCommand(id), ct);
+            return NoContent();
+        }
+        catch (DomainNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+    }
+}
+
+
+public sealed record CreateOrderRequest(string Currency);
+public sealed record UpdateOrderRequest(string Currency);
+public sealed record AddLineRequest(Guid ProductId, int Quantity);

--- a/src/DomainDrivenDesignShop.Api/Controllers/ProductsController.cs
+++ b/src/DomainDrivenDesignShop.Api/Controllers/ProductsController.cs
@@ -1,0 +1,117 @@
+using System.Collections.Generic;
+using DomainDrivenDesignShop.Application;
+using DomainDrivenDesignShop.Domain.Abstractions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DomainDrivenDesignShop.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public sealed class ProductsController(
+    CreateProductHandler createHandler,
+    UpdateProductHandler updateHandler,
+    DeleteProductHandler deleteHandler,
+    GetProductHandler getHandler,
+    ListProductsHandler listHandler) : ControllerBase
+{
+    private readonly CreateProductHandler _createHandler = createHandler;
+    private readonly UpdateProductHandler _updateHandler = updateHandler;
+    private readonly DeleteProductHandler _deleteHandler = deleteHandler;
+    private readonly GetProductHandler _getHandler = getHandler;
+    private readonly ListProductsHandler _listHandler = listHandler;
+
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<ProductDto>>> GetAllAsync(CancellationToken ct)
+    {
+        var result = await _listHandler.HandleAsync(new ListProductsQuery(), ct);
+        return Ok(result);
+    }
+
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<ProductDto>> GetByIdAsync(Guid id, CancellationToken ct)
+    {
+        try
+        {
+            var result = await _getHandler.HandleAsync(new GetProductQuery(id), ct);
+            return Ok(result);
+        }
+        catch (DomainNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+    }
+
+
+    [HttpPost]
+    public async Task<ActionResult<CreateProductResult>> CreateAsync([FromBody] UpsertProductRequest request, CancellationToken ct)
+    {
+        try
+        {
+            var result = await _createHandler.HandleAsync(
+                new CreateProductCommand(request.Name, request.Amount, request.Currency),
+                ct);
+
+            return CreatedAtAction(nameof(GetByIdAsync), new { id = result.ProductId }, result);
+        }
+        catch (DomainRuleViolationException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+
+
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> UpdateAsync(Guid id, [FromBody] UpsertProductRequest request, CancellationToken ct)
+    {
+        try
+        {
+            await _updateHandler.HandleAsync(new UpdateProductCommand(id, request.Name, request.Amount, request.Currency), ct);
+            return NoContent();
+        }
+        catch (DomainNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+        catch (DomainRuleViolationException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> DeleteAsync(Guid id, CancellationToken ct)
+    {
+        try
+        {
+            await _deleteHandler.HandleAsync(new DeleteProductCommand(id), ct);
+            return NoContent();
+        }
+        catch (DomainNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+    }
+
+
+    [HttpPost("seed")]
+    public async Task<ActionResult<IEnumerable<Guid>>> SeedAsync(CancellationToken ct)
+    {
+        var product1 = await _createHandler.HandleAsync(new CreateProductCommand("Café 250g", 5.90m, "EUR"), ct);
+        var product2 = await _createHandler.HandleAsync(new CreateProductCommand("Té Verde 100g", 3.50m, "EUR"), ct);
+
+        return Ok(new[] { product1.ProductId, product2.ProductId });
+    }
+}
+
+
+public sealed record UpsertProductRequest(string Name, decimal Amount, string Currency);

--- a/src/DomainDrivenDesignShop.Api/DomainDrivenDesignShop.Api.csproj
+++ b/src/DomainDrivenDesignShop.Api/DomainDrivenDesignShop.Api.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DomainDrivenDesignShop.Api/Program.cs
+++ b/src/DomainDrivenDesignShop.Api/Program.cs
@@ -1,20 +1,24 @@
 using DomainDrivenDesignShop.Application;
-using DomainDrivenDesignShop.Domain.Entities;
 using DomainDrivenDesignShop.Domain.Repositories;
-using DomainDrivenDesignShop.Domain.ValueObjects;
 using DomainDrivenDesignShop.Infrastructure.Persistence;
 using DomainDrivenDesignShop.Infrastructure.Repositories;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+builder.Services.AddControllers();
 
-// EF Core — InMemory para demo (puedes cambiar a SQL Server, PostgreSQL, etc.)
-builder.Services.AddDbContext<AppDbContext>(opt => opt.UseInMemoryDatabase("dddshop"));
+// EF Core — SQLite para persistencia local
+builder.Services.AddDbContext<AppDbContext>(opt =>
+{
+    var connectionString = builder.Configuration.GetConnectionString("Default")
+        ?? "Data Source=dddshop.db";
+    opt.UseSqlite(connectionString);
+});
 
 // Repositorios (puertos)
 builder.Services.AddScoped<IProductRepository, EfProductRepository>();
@@ -24,8 +28,23 @@ builder.Services.AddScoped<IUnitOfWork, EfUnitOfWork>();
 // Casos de uso
 builder.Services.AddScoped<CreateOrderHandler>();
 builder.Services.AddScoped<AddProductToOrderHandler>();
+builder.Services.AddScoped<CreateProductHandler>();
+builder.Services.AddScoped<UpdateProductHandler>();
+builder.Services.AddScoped<DeleteProductHandler>();
+builder.Services.AddScoped<GetProductHandler>();
+builder.Services.AddScoped<ListProductsHandler>();
+builder.Services.AddScoped<GetOrderHandler>();
+builder.Services.AddScoped<ListOrdersHandler>();
+builder.Services.AddScoped<UpdateOrderHandler>();
+builder.Services.AddScoped<DeleteOrderHandler>();
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    db.Database.EnsureCreated();
+}
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
@@ -33,36 +52,9 @@ if (app.Environment.IsDevelopment())
     app.MapOpenApi();
 }
 
+app.UseRouting();
 app.UseHttpsRedirection();
 
-app.MapPost("/orders", async ([FromBody] CreateOrderRequest req, CreateOrderHandler handler, CancellationToken ct) =>
-{
-    var result = await handler.HandleAsync(new CreateOrderCommand(req.Currency), ct);
-    return Results.Created($"/orders/{result.OrderId}", result);
-});
-
-
-app.MapPost("/orders/{orderId:guid}/lines", async (Guid orderId, [FromBody] AddLineRequest req, AddProductToOrderHandler handler, CancellationToken ct) =>
-{
-    await handler.HandleAsync(new AddProductToOrderCommand(orderId, req.ProductId, req.Quantity), ct);
-    return Results.NoContent();
-});
-
-
-// Semilla opcional para probar rápido
-app.MapPost("/seed", async (AppDbContext db) =>
-{
-    var p1 = Product.Create("Café 250g", Money.From(5.90m, "EUR"));
-    var p2 = Product.Create("Té Verde 100g", Money.From(3.50m, "EUR"));
-    db.Products.AddRange(p1, p2);
-    await db.SaveChangesAsync();
-    return Results.Ok(new { Product1Id = p1.Id, Product2Id = p2.Id });
-});
-
+app.MapControllers();
 
 app.Run();
-
-
-// DTOs API
-public sealed record CreateOrderRequest(string Currency);
-public sealed record AddLineRequest(Guid ProductId, int Quantity);

--- a/src/DomainDrivenDesignShop.Api/appsettings.Development.json
+++ b/src/DomainDrivenDesignShop.Api/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "Default": "Data Source=dddshop.db"
   }
 }

--- a/src/DomainDrivenDesignShop.Api/appsettings.json
+++ b/src/DomainDrivenDesignShop.Api/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "Default": "Data Source=dddshop.db"
+  },
   "AllowedHosts": "*"
 }

--- a/src/DomainDrivenDesignShop.Application/Orders.cs
+++ b/src/DomainDrivenDesignShop.Application/Orders.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Linq;
+using DomainDrivenDesignShop.Domain.Abstractions;
+using DomainDrivenDesignShop.Domain.Entities;
+using DomainDrivenDesignShop.Domain.Repositories;
+
+namespace DomainDrivenDesignShop.Application;
+
+public sealed record OrderLineDto(Guid Id, Guid ProductId, int Quantity, decimal UnitPrice, string Currency, decimal Subtotal);
+public sealed record OrderDto(Guid Id, DateTime CreatedAtUtc, string Currency, IReadOnlyList<OrderLineDto> Lines, decimal TotalAmount);
+
+public sealed record GetOrderQuery(Guid OrderId);
+
+public sealed class GetOrderHandler(IOrderRepository orders)
+{
+    private readonly IOrderRepository _orders = orders;
+
+    public async Task<OrderDto> HandleAsync(GetOrderQuery query, CancellationToken ct = default)
+    {
+        var order = await _orders.GetByIdAsync(query.OrderId, ct)
+            ?? throw DomainErrors.NotFound($"Pedido {query.OrderId}");
+
+        return Map(order);
+    }
+
+    private static OrderDto Map(Order order)
+    {
+        var lines = order.Lines
+            .Select(l => new OrderLineDto(l.Id, l.ProductId, l.Quantity, l.UnitPrice.Amount, l.UnitPrice.Currency, l.Subtotal().Amount))
+            .ToList();
+
+        return new OrderDto(order.Id, order.CreatedAtUtc, order.Currency, lines, order.Total().Amount);
+    }
+}
+
+
+public sealed record ListOrdersQuery;
+
+public sealed class ListOrdersHandler(IOrderRepository orders)
+{
+    private readonly IOrderRepository _orders = orders;
+
+    public async Task<IReadOnlyList<OrderDto>> HandleAsync(ListOrdersQuery query, CancellationToken ct = default)
+    {
+        var all = await _orders.GetAllAsync(ct);
+        return all.Select(Map).ToList();
+    }
+
+    private static OrderDto Map(Order order)
+    {
+        var lines = order.Lines
+            .Select(l => new OrderLineDto(l.Id, l.ProductId, l.Quantity, l.UnitPrice.Amount, l.UnitPrice.Currency, l.Subtotal().Amount))
+            .ToList();
+
+        return new OrderDto(order.Id, order.CreatedAtUtc, order.Currency, lines, order.Total().Amount);
+    }
+}
+
+
+public sealed record UpdateOrderCommand(Guid OrderId, string Currency);
+
+public sealed class UpdateOrderHandler(IOrderRepository orders, IUnitOfWork uow)
+{
+    private readonly IOrderRepository _orders = orders;
+    private readonly IUnitOfWork _uow = uow;
+
+    public async Task HandleAsync(UpdateOrderCommand cmd, CancellationToken ct = default)
+    {
+        var order = await _orders.GetByIdAsync(cmd.OrderId, ct)
+            ?? throw DomainErrors.NotFound($"Pedido {cmd.OrderId}");
+
+        order.UpdateCurrency(cmd.Currency);
+        _orders.Update(order);
+        await _uow.SaveChangesAsync(ct);
+    }
+}
+
+
+public sealed record DeleteOrderCommand(Guid OrderId);
+
+public sealed class DeleteOrderHandler(IOrderRepository orders, IUnitOfWork uow)
+{
+    private readonly IOrderRepository _orders = orders;
+    private readonly IUnitOfWork _uow = uow;
+
+    public async Task HandleAsync(DeleteOrderCommand cmd, CancellationToken ct = default)
+    {
+        var order = await _orders.GetByIdAsync(cmd.OrderId, ct)
+            ?? throw DomainErrors.NotFound($"Pedido {cmd.OrderId}");
+
+        _orders.Remove(order);
+        await _uow.SaveChangesAsync(ct);
+    }
+}

--- a/src/DomainDrivenDesignShop.Application/Products.cs
+++ b/src/DomainDrivenDesignShop.Application/Products.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Linq;
+using DomainDrivenDesignShop.Domain.Abstractions;
+using DomainDrivenDesignShop.Domain.Entities;
+using DomainDrivenDesignShop.Domain.Repositories;
+using DomainDrivenDesignShop.Domain.ValueObjects;
+
+namespace DomainDrivenDesignShop.Application;
+
+public sealed record ProductDto(Guid Id, string Name, decimal Amount, string Currency);
+
+public sealed record CreateProductCommand(string Name, decimal Amount, string Currency);
+public sealed record CreateProductResult(Guid ProductId);
+
+public sealed class CreateProductHandler(IProductRepository products, IUnitOfWork uow)
+{
+    private readonly IProductRepository _products = products;
+    private readonly IUnitOfWork _uow = uow;
+
+    public async Task<CreateProductResult> HandleAsync(CreateProductCommand cmd, CancellationToken ct = default)
+    {
+        var money = Money.From(cmd.Amount, cmd.Currency);
+        var product = Product.Create(cmd.Name, money);
+        await _products.AddAsync(product, ct);
+        await _uow.SaveChangesAsync(ct);
+        return new CreateProductResult(product.Id);
+    }
+}
+
+
+public sealed record UpdateProductCommand(Guid ProductId, string Name, decimal Amount, string Currency);
+
+public sealed class UpdateProductHandler(IProductRepository products, IUnitOfWork uow)
+{
+    private readonly IProductRepository _products = products;
+    private readonly IUnitOfWork _uow = uow;
+
+    public async Task HandleAsync(UpdateProductCommand cmd, CancellationToken ct = default)
+    {
+        var product = await _products.GetByIdAsync(cmd.ProductId, ct)
+            ?? throw DomainErrors.NotFound($"Producto {cmd.ProductId}");
+
+        product.Update(cmd.Name, Money.From(cmd.Amount, cmd.Currency));
+        _products.Update(product);
+        await _uow.SaveChangesAsync(ct);
+    }
+}
+
+
+public sealed record DeleteProductCommand(Guid ProductId);
+
+public sealed class DeleteProductHandler(IProductRepository products, IUnitOfWork uow)
+{
+    private readonly IProductRepository _products = products;
+    private readonly IUnitOfWork _uow = uow;
+
+    public async Task HandleAsync(DeleteProductCommand cmd, CancellationToken ct = default)
+    {
+        var product = await _products.GetByIdAsync(cmd.ProductId, ct)
+            ?? throw DomainErrors.NotFound($"Producto {cmd.ProductId}");
+
+        _products.Remove(product);
+        await _uow.SaveChangesAsync(ct);
+    }
+}
+
+
+public sealed record GetProductQuery(Guid ProductId);
+
+public sealed class GetProductHandler(IProductRepository products)
+{
+    private readonly IProductRepository _products = products;
+
+    public async Task<ProductDto> HandleAsync(GetProductQuery query, CancellationToken ct = default)
+    {
+        var product = await _products.GetByIdAsync(query.ProductId, ct)
+            ?? throw DomainErrors.NotFound($"Producto {query.ProductId}");
+
+        return Map(product);
+    }
+
+    private static ProductDto Map(Product product)
+        => new(product.Id, product.Name, product.Price.Amount, product.Price.Currency);
+}
+
+
+public sealed record ListProductsQuery;
+
+public sealed class ListProductsHandler(IProductRepository products)
+{
+    private readonly IProductRepository _products = products;
+
+    public async Task<IReadOnlyList<ProductDto>> HandleAsync(ListProductsQuery query, CancellationToken ct = default)
+    {
+        var all = await _products.GetAllAsync(ct);
+        return all.Select(Map).ToList();
+    }
+
+    private static ProductDto Map(Product product)
+        => new(product.Id, product.Name, product.Price.Amount, product.Price.Currency);
+}

--- a/src/DomainDrivenDesignShop.Domain/Abstractions/Errors.cs
+++ b/src/DomainDrivenDesignShop.Domain/Abstractions/Errors.cs
@@ -1,6 +1,10 @@
 namespace DomainDrivenDesignShop.Domain.Abstractions;
 public static class DomainErrors
 {
-    public static Exception NotFound(string what) => new InvalidOperationException($"{what} no encontrado.");
-    public static Exception RuleViolation(string message) => new InvalidOperationException(message);
+    public static Exception NotFound(string what) => new DomainNotFoundException($"{what} no encontrado.");
+    public static Exception RuleViolation(string message) => new DomainRuleViolationException(message);
 }
+
+
+public sealed class DomainNotFoundException(string message) : InvalidOperationException(message);
+public sealed class DomainRuleViolationException(string message) : InvalidOperationException(message);

--- a/src/DomainDrivenDesignShop.Domain/Entities/Order.cs
+++ b/src/DomainDrivenDesignShop.Domain/Entities/Order.cs
@@ -51,4 +51,21 @@ public sealed class Order
         }
         return total;
     }
+
+
+    public void UpdateCurrency(string currency)
+    {
+        if (string.IsNullOrWhiteSpace(currency) || currency.Length != 3)
+        {
+            throw new ArgumentException("La divisa del pedido debe ser ISO de 3 letras.");
+        }
+
+        var normalized = currency.ToUpperInvariant();
+        if (_lines.Count > 0 && normalized != Currency)
+        {
+            throw DomainErrors.RuleViolation("No se puede cambiar la divisa de un pedido con líneas.");
+        }
+
+        Currency = normalized;
+    }
 }

--- a/src/DomainDrivenDesignShop.Domain/Entities/Product.cs
+++ b/src/DomainDrivenDesignShop.Domain/Entities/Product.cs
@@ -22,4 +22,12 @@ public sealed class Product
 
 
     public static Product Create(string name, Money price) => new(Guid.NewGuid(), name, price);
+
+
+    public void Update(string name, Money price)
+    {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("El nombre es requerido.");
+        Name = name.Trim();
+        Price = price ?? throw new ArgumentNullException(nameof(price));
+    }
 }

--- a/src/DomainDrivenDesignShop.Domain/Repositories/IRepositories.cs
+++ b/src/DomainDrivenDesignShop.Domain/Repositories/IRepositories.cs
@@ -5,6 +5,10 @@ namespace DomainDrivenDesignShop.Domain.Repositories;
 public interface IProductRepository
 {
     Task<Product?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<IReadOnlyList<Product>> GetAllAsync(CancellationToken ct = default);
+    Task AddAsync(Product product, CancellationToken ct = default);
+    void Update(Product product);
+    void Remove(Product product);
 }
 
 
@@ -12,6 +16,9 @@ public interface IOrderRepository
 {
     Task<Order?> GetByIdAsync(Guid id, CancellationToken ct = default);
     Task AddAsync(Order order, CancellationToken ct = default);
+    Task<IReadOnlyList<Order>> GetAllAsync(CancellationToken ct = default);
+    void Update(Order order);
+    void Remove(Order order);
 }
 
 

--- a/src/DomainDrivenDesignShop.Infrastructure/DomainDrivenDesignShop.Infrastructure.csproj
+++ b/src/DomainDrivenDesignShop.Infrastructure/DomainDrivenDesignShop.Infrastructure.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.9" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/DomainDrivenDesignShop.Infrastructure/Repositories/EfRepositories.cs
+++ b/src/DomainDrivenDesignShop.Infrastructure/Repositories/EfRepositories.cs
@@ -12,7 +12,23 @@ public sealed class EfProductRepository : IProductRepository
 
 
     public Task<Product?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    => _db.Products.AsNoTracking().FirstOrDefaultAsync(p => p.Id == id, ct);
+        => _db.Products.FirstOrDefaultAsync(p => p.Id == id, ct);
+
+
+    public async Task<IReadOnlyList<Product>> GetAllAsync(CancellationToken ct = default)
+        => await _db.Products.AsNoTracking().ToListAsync(ct);
+
+
+    public Task AddAsync(Product product, CancellationToken ct = default)
+        => _db.Products.AddAsync(product, ct).AsTask();
+
+
+    public void Update(Product product)
+        => _db.Products.Update(product);
+
+
+    public void Remove(Product product)
+        => _db.Products.Remove(product);
 }
 
 
@@ -23,11 +39,25 @@ public sealed class EfOrderRepository : IOrderRepository
 
 
     public Task<Order?> GetByIdAsync(Guid id, CancellationToken ct = default)
-    => _db.Orders.Include(o => o.Lines).FirstOrDefaultAsync(o => o.Id == id, ct);
+        => _db.Orders.Include(o => o.Lines).FirstOrDefaultAsync(o => o.Id == id, ct);
 
 
     public async Task AddAsync(Order order, CancellationToken ct = default)
-    => await _db.Orders.AddAsync(order, ct);
+        => await _db.Orders.AddAsync(order, ct);
+
+
+    public async Task<IReadOnlyList<Order>> GetAllAsync(CancellationToken ct = default)
+        => await _db.Orders.Include(o => o.Lines)
+                           .AsNoTracking()
+                           .ToListAsync(ct);
+
+
+    public void Update(Order order)
+        => _db.Orders.Update(order);
+
+
+    public void Remove(Order order)
+        => _db.Orders.Remove(order);
 }
 
 


### PR DESCRIPTION
## Summary
- switch EF Core configuration from the in-memory provider to SQLite and configure the default connection string
- extend the domain, application, and infrastructure layers with CRUD support for products and orders
- replace minimal API endpoints with MVC controllers that expose CRUD endpoints and seed helper actions

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dabe66bbe4832fb265a5c41ee6d12d